### PR TITLE
Don't allow scripts to complete test run

### DIFF
--- a/lib/probe/controllers/run.ex
+++ b/lib/probe/controllers/run.ex
@@ -45,10 +45,14 @@ defmodule Probe.Controllers.Run do
     end
   end
 
-  def complete(conn, %{"id" => id}) do
+  def status(conn, %{"id" => id}) do
     {:ok, run} = Probe.Runs.fetch_run(id)
-    Probe.PubSub.broadcast("run:#{run.topic}", {:completed, run.id})
-    send_resp(conn, 200, "")
+
+    if run.completed_at do
+      send_resp(conn, 200, "done")
+    else
+      send_resp(conn, 200, "running")
+    end
   end
 
   def cancel(conn, %{"id" => id}) do

--- a/lib/probe/live/component/run.ex
+++ b/lib/probe/live/component/run.ex
@@ -20,7 +20,7 @@ defmodule Probe.Live.Component.Run do
           Test your WireGuard connectivity
         </h1>
         <p class="underline text-gray-600 dark:text-gray-400 mt-4">
-          <i>No WireGuard client required!</i>
+          <i>No WireGuard® client required!</i>
         </p>
       </div>
       <%= if @os && @os =~ ~r/(Mac OS X|Windows|Linux|FreeBSD|OpenBSD)/ do %>

--- a/lib/probe/router.ex
+++ b/lib/probe/router.ex
@@ -14,8 +14,8 @@ defmodule Probe.Router do
     plug :accepts, ["text"]
 
     post "/runs/:token/start", Probe.Controllers.Run, :start
-    post "/runs/:id/complete", Probe.Controllers.Run, :complete
     post "/runs/:id/cancel", Probe.Controllers.Run, :cancel
+    get "/runs/:id/status", Probe.Controllers.Run, :status
     get "/runs/:id", Probe.Controllers.Run, :show
   end
 

--- a/lib/probe/runs/udp_server.ex
+++ b/lib/probe/runs/udp_server.ex
@@ -167,7 +167,7 @@ defmodule Probe.Runs.UdpServer do
   defp broadcast(run_id, event) do
     with {:ok, run_id} <- Ecto.UUID.load(run_id),
          {:ok, run} <- Runs.fetch_run(run_id) do
-      Probe.PubSub.broadcast("run:#{run.topic}", event)
+      Probe.PubSub.broadcast("run:#{run.topic}", {event, run_id})
     else
       _ -> {:error, :invalid_run_id}
     end

--- a/priv/static/scripts/windows.ps1
+++ b/priv/static/scripts/windows.ps1
@@ -71,7 +71,26 @@ try {
     Write-Host "."
     Send-Payload -payload $turn_data_message -probe_host $probe_host -port $port
 
-    Invoke-RestMethod -Method Post -Uri "$run_url/complete" -Headers @{Accept = 'text/plain'} -UseBasicParsing
+# Wait for test to complete
+    Write-Output "Waiting for test to complete..."
+    $counter = 0
+    $max_attempts = 10
+    while ($counter -lt $max_attempts) {
+        $status = Invoke-RestMethod -Method Get -Uri "$run_url/status" -Headers @{Accept = 'text/plain'} -UseBasicParsing
+
+        if ($status -eq "done") {
+            break
+        }
+
+        Start-Sleep -Seconds 1
+        Write-Output "."
+        $counter++
+    }
+
+    if ($counter -eq $max_attempts) {
+        Write-Output "Test did not complete within time. Exiting."
+        exit 1
+    }
 
     $result = Invoke-RestMethod -Method Get -Uri "$run_url" -Headers @{Accept = 'text/plain'} -UseBasicParsing
     Write-Host "Done! Test completed. Results:"


### PR DESCRIPTION
I was hitting some Phoenix router bug using `head` -- it was still matching `get` for some reason. Ended up just returning a simple body instead.