### PR TITLE
remove -4 from gnu netcat

### DIFF
--- a/priv/static/scripts/unix.sh
+++ b/priv/static/scripts/unix.sh
@@ -21,7 +21,7 @@ trap cancel EXIT
 send_payload() {
     payload=$1
     for i in 1 2 3; do
-        echo "$payload" | base64 -d | nc -4 -u -w 0 "$host" "$port"
+        echo "$payload" | base64 -d | nc -u -w 0 "$host" "$port"
         sleep $payload_interval
     done
 }


### PR DESCRIPTION
This was added but is unnecessary -- we only send an IPv4 address to connect to.