### PR TITLE
Ensure docker-compose.yml works with Podman Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:15.5
+    image: docker.io/postgres:15.5
     volumes:
       - postgres-data:/var/lib/postgresql/data
     environment:


### PR DESCRIPTION
Resolves the following error:

Error: short-name "postgres:15.5" did not resolve to an alias and no unqualified-search registries are defined in
"/etc/containers/registries.conf"